### PR TITLE
2by2 crafting support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>CraftEnhance</groupId>
 	<artifactId>CraftEnhance</artifactId>
-	<version>2.4.0</version>
+	<version>2.4.2</version>
 	<name>CraftEnhance</name>
 	<description>This is a minecraft plugin to enhance crafting.</description>
 	<properties>
@@ -32,13 +32,18 @@
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
+
+        <repository>
+            <id>minecraft-repo</id>
+            <url>https://libraries.minecraft.net/</url>
+        </repository>
 	</repositories>
 	<dependencies>
 		<dependency>
 			<!--- Spigot api -->
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.16.1-R0.1-SNAPSHOT</version>
+			<version>1.13.2-R0.1-SNAPSHOT</version>
 		</dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -46,6 +51,13 @@
             <version>1.18.12</version>
             <scope>provided</scope>
         </dependency>
+
+		<dependency>
+			<groupId>com.mojang</groupId>
+			<artifactId>authlib</artifactId>
+			<version>1.5.21</version>
+			<scope>provided</scope>
+		</dependency>
         <!--<dependency>-->
             <!--<groupId>org.bukkit</groupId>-->
             <!--<artifactId>bukkit</artifactId>-->

--- a/src/main/java/com/dutchjelly/bukkitadapter/Adapter.java
+++ b/src/main/java/com/dutchjelly/bukkitadapter/Adapter.java
@@ -1,26 +1,21 @@
 package com.dutchjelly.bukkitadapter;
 
 
-import com.dutchjelly.craftenhance.messaging.Debug;
-import com.dutchjelly.craftenhance.messaging.Messenger;
 import org.bukkit.Material;
 
 import org.bukkit.NamespacedKey;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.Recipe;
-import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import org.bukkit.DyeColor;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class Adapter {
 
@@ -88,6 +83,10 @@ public class Adapter {
 //    public static void DiscoverRecipes(Player player, List<Recipe> recipes){
 //        return;
 //    }
+//
+//    public static void SetOwningPlayer(SkullMeta meta, OfflinePlayer player){
+//        meta.setOwner(player.getName());
+//    }
 
     /**
      * section for 1.12
@@ -123,12 +122,14 @@ public class Adapter {
 //    public static void DiscoverRecipes(Player player, List<Recipe> recipes){
 //        return;
 //    }
-
+//    public static void SetOwningPlayer(SkullMeta meta, OfflinePlayer player){
+//        meta.setOwningPlayer(player);
+//    }
     /**
      * section for 1.13+
-     * TODO: add AddIngredient and GetShapelessRecipe to this section
+     *
      */
-
+//
     public static List<String> CompatibleVersions(){
         return Arrays.asList("1.13", "1.14", "1.15", "1.16");
     }
@@ -149,11 +150,11 @@ public class Adapter {
     }
 
     public static void AddIngredient(ShapelessRecipe recipe, ItemStack ingredient){
-        recipe.addIngredient(ingredient.getType());
+        recipe.addIngredient(new RecipeChoice.ExactChoice(ingredient));
     }
 
     public static void SetIngredient(ShapedRecipe recipe, char key, ItemStack ingredient){
-        recipe.setIngredient(key, ingredient.getType());
+        recipe.setIngredient(key, new RecipeChoice.ExactChoice(ingredient));
     }
 
     public static void DiscoverRecipes(Player player, List<Recipe> recipes){
@@ -167,6 +168,8 @@ public class Adapter {
             }
         }
     }
-
+    public static void SetOwningPlayer(SkullMeta meta, OfflinePlayer player){
+        meta.setOwningPlayer(player);
+    }
 
 }

--- a/src/main/java/com/dutchjelly/craftenhance/gui/util/SkullCreator.java
+++ b/src/main/java/com/dutchjelly/craftenhance/gui/util/SkullCreator.java
@@ -123,7 +123,7 @@ public class SkullCreator {
         notNull(id, "id");
 
         SkullMeta meta = (SkullMeta) item.getItemMeta();
-        meta.setOwningPlayer(Bukkit.getOfflinePlayer(id));
+        Adapter.SetOwningPlayer(meta,Bukkit.getOfflinePlayer(id));
         item.setItemMeta(meta);
 
         return item;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 author: DutchJelly
 main: com.dutchjelly.craftenhance.CraftEnhance
 name: CraftEnhance
-version: 2.4.0
+version: 2.4.2
 api-version: 1.13
 commands:
   recipes:


### PR DESCRIPTION
The plugin now properly supports 2by2 crafting. In this pull request a rare-occuring bug that had to do with determining the offset of a recipe while comparing was found and fixed. The unit tests didn't uncover this bug, and still run succesfull after the fix.

Fixes #18 